### PR TITLE
Add in-memory caching for API responses

### DIFF
--- a/server/src/cache.js
+++ b/server/src/cache.js
@@ -1,0 +1,23 @@
+const cache = {};
+
+function setCache(key, data) {
+  cache[key] = {
+    data,
+    expiry: Date.now() + 5 * 60 * 1000
+  };
+}
+
+function getCache(key) {
+  const entry = cache[key];
+
+  if (!entry) return null;
+
+  if (Date.now() > entry.expiry) {
+    delete cache[key];
+    return null;
+  }
+
+  return entry.data;
+}
+
+module.exports = { setCache, getCache };


### PR DESCRIPTION
Use in API.

const { setCache, getCache } = require("../utils/cache");

const key = `${lat}-${lon}`;
const cached = getCache(key);

if (cached) {
  return res.json(cached);
}

setCache(key, response.data);